### PR TITLE
Load data on project load immediately if possible

### DIFF
--- a/src/SunburstClusterPlugin.cpp
+++ b/src/SunburstClusterPlugin.cpp
@@ -371,13 +371,18 @@ void SunburstClusterPlugin::fromVariantMap(const QVariantMap& variantMap)
         _currentClusterDataSets.emplace_back(mv::data().getDataset<Clusters>(clusterDataGuid));
     }
 
-    // capture the connection by value and define a mutable lambda which removes the connection
-    QMetaObject::Connection conn;
-    conn = QObject::connect(_sunburstWidget, &gui::WebWidget::webPageFullyLoaded, [this, conn]() mutable {
+    if (_sunburstWidget->isWebPageLoaded()) { // ideally we'd also cheeck _communicationAvailable from gui::WebWidget
+      loadDataImpl();
+    }
+    else {
+      // capture the connection by value and define a mutable lambda which removes the connection
+      QMetaObject::Connection conn;
+      conn = QObject::connect(_sunburstWidget, &gui::WebWidget::webPageFullyLoaded, [this, conn]() mutable {
         // Disconnect this connection
         QObject::disconnect(conn);
         loadDataImpl();
         });
+    }
 }
 
 QVariantMap SunburstClusterPlugin::toVariantMap() const


### PR DESCRIPTION
When loading a project, ManiVault first calls all `init()` of each loaded plugin and at the end all `fromVariantMap()` functions.
If another plugin has a long processing time, the webpage in the Sunburst plugin will already be loaded, and the connected that was established in `fromVariantMap()` would never trigger.

So, best check in `fromVariantMap()` if you can just pass the data to the plot directly.